### PR TITLE
nuget publication

### DIFF
--- a/.github/workflows/publish-nuget.yml
+++ b/.github/workflows/publish-nuget.yml
@@ -1,0 +1,24 @@
+name: Publish Nuget
+
+on: 
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 8.0.x
+    - name: Test
+      run: dotnet test tests/tests.csproj
+    - name: Pack
+      run: |
+        dotnet pack ./lib --configuration Release --include-source --include-symbols --output packages
+        ls packages
+    - name: Push
+      run: |
+        dotnet nuget push packages/ -k ${{ secrets.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
+    

--- a/lib/KtxSharp.csproj
+++ b/lib/KtxSharp.csproj
@@ -2,16 +2,17 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
-    <PackageId>LibKTX</PackageId>
+    <PackageId>BrewedInk.LibKTX</PackageId>
     <VersionPrefix>0.9.2</VersionPrefix>
     <VersionSuffix>$(VersionSuffix)</VersionSuffix>
     <Authors>Kaarlo Räihä</Authors>
-    <Description>.Net Standard compatible managed library for handling KTX File Format (only KTX 1, not KTX 2) for texture data</Description>
+    <Description>.Net Standard compatible managed library for handling KTX File Format (only KTX 1, not KTX 2) for texture data. This publication is a fork of the library and may fall out of date. </Description>
     <IncludeSource>true</IncludeSource>
-    <PackageProjectUrl>https://github.com/mcraiha/libktxsharp</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/mcraiha/libktxsharp.git</RepositoryUrl>
+    <PackageProjectUrl>https://github.com/cdhanna/libktxsharp</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/cdhanna/libktxsharp.git</RepositoryUrl>
     <PackageLicenseExpression>Unlicense</PackageLicenseExpression>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+
   </PropertyGroup>
 
 </Project>


### PR DESCRIPTION
Hi, 
This is a terrific library, and I needed to be able to consume it via nuget instead of direct dll build. 

I forked the project and changed the nuget settings to publish it to `BrewedInk.LibKTX`, https://www.nuget.org/packages/BrewedInk.LibKTX/#supportedframeworks-body-tab. 

To do this, I had to create a nuget account, create an API key, and then set that API key in my fork's github secrets. 

I know this PR cannot be accepted directly as is, but I hoped it would serve useful to the maintainer of this project if they want to set up a nuget distribution helper on their own. 